### PR TITLE
Update versions for PhotonOS, Docker-Compose and Harbor

### DIFF
--- a/photon-version.json
+++ b/photon-version.json
@@ -1,10 +1,9 @@
 {
-  "version": "2.3.0",
+  "version": "2.4.1",
   "description": "VMware Harbor Appliance",
   "vm_name": "VMware_Harbor_Appliance",
-  "iso_checksum": "248b9916bc60698bdc8aeecf17547cac98c52f60b69d3ec4848e1df6ba4b8e72af8cff0557ac303928beef4e299ca1090c5369d739e97f19d683d84e9c72bc6d",
-  "iso_checksum_type": "sha512",
-  "iso_url": "https://packages.vmware.com/photon/3.0/Rev2/iso/Update2/photon-3.0-a0f216d.iso",
+  "iso_checksum": "5af288017d0d1198dd6bd02ad40120eb",
+  "iso_url": "https://packages.vmware.com/photon/4.0/Rev2/iso/photon-4.0-c001795b8.iso",
   "numvcpus": "2",
   "ramsize": "4096",
   "guest_username": "root",

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -25,13 +25,12 @@ echo '> Creating directory for setup scripts'
 mkdir -p /root/setup
 
 echo ' > Downloading Harbor...'
-HARBOR_VERSION=2.3.0
+HARBOR_VERSION=2.4.1
 curl -L https://github.com/goharbor/harbor/releases/download/v${HARBOR_VERSION}/harbor-offline-installer-v${HARBOR_VERSION}.tgz -o harbor-offline-installer-v${HARBOR_VERSION}.tgz
 tar xvzf harbor-offline-installer*.tgz
 rm -f harbor-offline-installer-v${HARBOR_VERSION}.tgz
 
 echo '> Downloading docker-compose...'
-DOCKER_COMPOSE_VERSION=1.29.2
-curl -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+DOCKER_COMPOSE_VERSION=2.3.3
+curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
-


### PR DESCRIPTION
This PR will update the Harbor-Appliance components from:

`PhotonOS v3 Rev.2`
`docker-compose v1.29.2`
`Harbor v2.3.0`

to

`PhotonOS v4 Rev.2`
`docker-compose v2.3.3`
`Harbor v2.4.1`

Tested:
- successful appliance build
- All containers up and running
- Harbor portal is accessible

![new-version](https://user-images.githubusercontent.com/31652019/157687563-2dd53b4e-2f72-472f-8aa3-c519bf1f42c2.png)

![harbor-version](https://user-images.githubusercontent.com/31652019/157687587-2882db83-0238-425a-81bf-73dfe199a280.png)


Closes: #1
Signed-off-by: Robert Guske <rguske@vmware.com>