### PR TITLE
Bump harbor to v2.5.3 and docker-compose to v2.9.0

### DIFF
--- a/photon-version.json
+++ b/photon-version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.1",
+  "version": "2.5.3",
   "description": "VMware Harbor Appliance",
   "vm_name": "VMware_Harbor_Appliance",
   "iso_checksum": "5af288017d0d1198dd6bd02ad40120eb",

--- a/scripts/photon-settings.sh
+++ b/scripts/photon-settings.sh
@@ -25,12 +25,12 @@ echo '> Creating directory for setup scripts'
 mkdir -p /root/setup
 
 echo ' > Downloading Harbor...'
-HARBOR_VERSION=2.4.1
+HARBOR_VERSION=2.5.3
 curl -L https://github.com/goharbor/harbor/releases/download/v${HARBOR_VERSION}/harbor-offline-installer-v${HARBOR_VERSION}.tgz -o harbor-offline-installer-v${HARBOR_VERSION}.tgz
 tar xvzf harbor-offline-installer*.tgz
 rm -f harbor-offline-installer-v${HARBOR_VERSION}.tgz
 
 echo '> Downloading docker-compose...'
-DOCKER_COMPOSE_VERSION=2.3.3
+DOCKER_COMPOSE_VERSION=2.9.0
 curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
This PR will bump the Harbor version from v2.4.1 to v2.5.3. It also updates docker-compose from v2.3.3 to v2.9.0.

* Changes tested and verified locally
* Appliance build ran successfully
* Deployment as well
![harbor-2-5-3](https://user-images.githubusercontent.com/31652019/182383619-2689f779-a509-4f44-b818-f0131a0068ab.png)

Closes: #7
Signed-off-by: Robert Guske <rguske@vmware.com>