### PR TITLE
Add new harbor systemd unit to the appliance

### DIFF
--- a/files/setup-03-harbor.sh
+++ b/files/setup-03-harbor.sh
@@ -66,3 +66,21 @@ rm -f harbor.*.gz
 
 # Waiting for Harbor to be ready, sleeping for 90 seconds
 sleep 90
+
+#Enable Harbor as a Systemd Service
+
+cat > /etc/systemd/system/harbor.service << __HARBOR_SYSTEMD__
+[Unit]
+Description=Harbor Service
+After=network.target docker.service
+[Service]
+Type=simple
+WorkingDirectory=/root/harbor
+ExecStart=/usr/local/bin/docker-compose -f /root/harbor/docker-compose.yml start
+ExecStop=/usr/local/bin/docker-compose -f /root/harbor/docker-compose.yml stop
+RemainAfterExit=yes
+[Install]
+WantedBy=multi-user.target
+__HARBOR_SYSTEMD__
+
+systemctl enable harbor


### PR DESCRIPTION
Add a Harbor systemd unit to ensure that all Harbor containers will be started after an appliance reboot.

* Verified changes locally
* Appliance build successfully

```shell
root@harbor-app [ ~ ]# systemctl status harbor.service 
● harbor.service - Harbor Service
     Loaded: loaded (/etc/systemd/system/harbor.service; enabled; vendor preset: enabled)
     Active: active (exited) since Tue 2022-08-02 14:43:41 UTC; 1min 5s ago
    Process: 1487 ExecStart=/usr/local/bin/docker-compose -f /root/harbor/docker-compose.yml start (code=exited, status=0/SUCCESS)
   Main PID: 1487 (code=exited, status=0/SUCCESS)

Aug 02 14:43:41 harbor-app.jarvis.lab systemd[1]: Started Harbor Service.

root@harbor-app [ ~ ]# docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED          STATUS                        PORTS                                                                            NAMES
9dfd3d8c7f2f   goharbor/harbor-jobservice:v2.5.3    "/harbor/entrypoint.…"   11 minutes ago   Up About a minute (healthy)                                                                                    harbor-jobservice
88faa294b56f   goharbor/nginx-photon:v2.5.3         "nginx -g 'daemon of…"   11 minutes ago   Up About a minute (healthy)   0.0.0.0:80->8080/tcp, :::80->8080/tcp, 0.0.0.0:443->8443/tcp, :::443->8443/tcp   nginx
278a4eaca665   goharbor/harbor-core:v2.5.3          "/harbor/entrypoint.…"   11 minutes ago   Up About a minute (healthy)                                                                                    harbor-core
81f4dfa533d1   goharbor/harbor-db:v2.5.3            "/docker-entrypoint.…"   11 minutes ago   Up About a minute (healthy)                                                                                    harbor-db
3adae99cae08   goharbor/harbor-portal:v2.5.3        "nginx -g 'daemon of…"   11 minutes ago   Up About a minute (healthy)                                                                                    harbor-portal
c76117946fe1   goharbor/harbor-registryctl:v2.5.3   "/home/harbor/start.…"   11 minutes ago   Up About a minute (healthy)                                                                                    registryctl
5e695573dd74   goharbor/redis-photon:v2.5.3         "redis-server /etc/r…"   11 minutes ago   Up About a minute (healthy)                                                                                    redis
1e0473c88486   goharbor/registry-photon:v2.5.3      "/home/harbor/entryp…"   11 minutes ago   Up About a minute (healthy)                                                                                    registry
1886671c20ab   goharbor/harbor-log:v2.5.3           "/bin/sh -c /usr/loc…"   11 minutes ago   Up About a minute (healthy)   127.0.0.1:1514->10514/tcp
```

Closes: #6
Signed-off-by: Robert Guske <rguske@vmware.com>